### PR TITLE
Add ability to send input image and mask to img2img inpaint tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ To download the model:
 ### Mask only Tab
 
 * Gives ability to just save mask without any other processing, so it's then possible to use the mask in img2img's `Inpaint upload` with any model/extensions/tools you already have in your AUTOMATIC1111.
+* After the `Get mask` button press you can use `Send to img2img inpaint` button under the mask image to send both input image and mask to the img2img tab.
 
 ## Auto-saving images
 

--- a/javascript/inpaint-anything.js
+++ b/javascript/inpaint-anything.js
@@ -1,0 +1,77 @@
+async function inpaintAnything_sendToInpaint() {
+
+	const waitForElement = async (
+	    parent,
+	    selector,
+	    exist
+	) => {
+	    return new Promise((resolve) => {
+	        const observer = new MutationObserver(() => {
+	            if (!!parent.querySelector(selector) != exist) {
+	                return;
+	            }
+	            observer.disconnect();
+	            resolve(undefined);
+	        })
+
+	        observer.observe(parent, {
+	            childList: true,
+	            subtree: true,
+	        })
+
+	        if (!!parent.querySelector(selector) == exist) {
+	            resolve(undefined);
+	        }
+	    })
+	}
+
+	const timeout = (ms) => {
+	    return new Promise(function (resolve, reject) {
+	        setTimeout(() => reject('Timeout'), ms)
+	    })
+	};
+
+	const waitForElementToBeInDocument = (parent, selector) => Promise.race([waitForElement(parent, selector, true), timeout(10000)]);
+
+	const waitForElementToBeRemoved = (parent, selector) => Promise.race([waitForElement(parent, selector, false), timeout(10000)]);
+
+	const updateGradioImage = async (element, url, name) => {
+	    const blob = await (await fetch(url)).blob();
+	    const file = new File([blob], name);
+	    const dt = new DataTransfer();
+	    dt.items.add(file);
+
+	    element
+	        .querySelector("button[aria-label='Clear']")
+	        ?.click();
+	    await waitForElementToBeRemoved(element, "button[aria-label='Clear']");
+	    const input = element.querySelector("input[type='file']");
+	    input.value = '';
+	    input.files = dt.files;
+	    input.dispatchEvent(
+	        new Event('change', {
+	            bubbles: true,
+	            composed: true,
+	        })
+	    );
+	    await waitForElementToBeInDocument(element, "button[aria-label='Clear']");
+	}
+
+	const inputImg = document.querySelector("#input_image img");
+	const maskImg = document.querySelector("#mask_out_image img");
+
+	if (!inputImg || !maskImg) {
+		return;
+	}
+
+	const inputImgDataUrl = inputImg.src;
+	const maskImgDataUrl = maskImg.src;
+
+	window.scrollTo(0, 0);
+	switch_to_img2img_tab(4);
+
+	await waitForElementToBeInDocument(document.querySelector("#img2img_inpaint_upload_tab"), "#img_inpaint_base");
+
+	await updateGradioImage(document.querySelector("#img_inpaint_base"), inputImgDataUrl, "input.png");
+	await updateGradioImage(document.querySelector("#img_inpaint_mask"), maskImgDataUrl, "mask.png");
+}

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -567,11 +567,13 @@ def on_ui_tabs():
 
                 with gr.Tab("Mask only"):
                     with gr.Row():
-                        with gr.Column():
-                            with gr.Row():
-                                get_mask_btn = gr.Button("Get mask", elem_id="get_mask_btn")
+                        get_mask_btn = gr.Button("Get mask", elem_id="get_mask_btn")
                     
-                    mask_out_image = gr.Image(label="Mask image", elem_id="mask_out_image", interactive=False).style(height=480)
+                    with gr.Row():
+                        mask_out_image = gr.Image(label="Mask image", elem_id="mask_out_image", interactive=False).style(height=480)
+
+                    with gr.Row():
+                        mask_send_to_inpaint_btn = gr.Button("Send to img2img inpaint", elem_id="mask_send_to_inpaint_btn")
 
                 
             with gr.Column():
@@ -611,6 +613,11 @@ def on_ui_tabs():
                 run_get_mask,
                 inputs=[sel_mask],
                 outputs=[mask_out_image])
+            mask_send_to_inpaint_btn.click(
+                fn=None,
+                _js="inpaintAnything_sendToInpaint",
+                inputs=None,
+                outputs=None)
     
     return [(inpaint_anything_interface, "Inpaint Anything", "inpaint_anything")]
 


### PR DESCRIPTION
Small refactor of UI, removed rows and columns.

Added a button to that feature with mask download - now we can send input and mask to img2img tab in 1 click.