### PR TITLE
Allow expanding a mask by drawing

### DIFF
--- a/scripts/main.py
+++ b/scripts/main.py
@@ -260,11 +260,14 @@ def expand_mask(input_image, sel_mask, expand_iteration=1):
         return None
     
     new_sel_mask = sam_dict["mask_image"]
-    
-    expand_iteration = int(np.clip(expand_iteration, 1, 5))
-    
-    for i in range(expand_iteration):
-        new_sel_mask = np.array(cv2.dilate(new_sel_mask, np.ones((3, 3), dtype=np.uint8), iterations=1))
+
+    drawn_mask = sel_mask["mask"][:,:,0:3].astype(bool).astype(np.uint8)
+    if np.any(drawn_mask):
+        new_sel_mask = new_sel_mask - drawn_mask
+    else:
+        expand_iteration = int(np.clip(expand_iteration, 1, 5))
+        for i in range(expand_iteration):
+            new_sel_mask = np.array(cv2.dilate(new_sel_mask, np.ones((3, 3), dtype=np.uint8), iterations=1))
     
     sam_dict["mask_image"] = new_sel_mask
 


### PR DESCRIPTION
I noticed that "expand mask" doesn't take anything I draw on the image into account; only trimming from the sketch seems to be possible.

I made it so that if you sketch on the mask image, clicking "Expand mask" applies the drawn parts to the mask instead of doing the dilating expansion. If there is no drawing, it'll do the usual expansion.

I noticed that there's an issue in that after applying the drawn mask, the drawing disappears but seems to still remain invisibly there until I click the eraser button to "reset" the sketch.

I don't know how to fix that; is it a Gradio bug or does something need to be done to reset it?