### PR TITLE
Feature: Add Slider for "Expand Mask" Iteration Count

### DIFF
--- a/scripts/inpaint_anything.py
+++ b/scripts/inpaint_anything.py
@@ -234,7 +234,7 @@ def expand_mask(input_image, sel_mask, expand_iteration=1):
 
     new_sel_mask = sam_dict["mask_image"]
 
-    expand_iteration = int(np.clip(expand_iteration, 1, 5))
+    expand_iteration = int(np.clip(expand_iteration, 1, 100))
 
     new_sel_mask = cv2.dilate(new_sel_mask, np.ones((3, 3), dtype=np.uint8), iterations=expand_iteration)
 

--- a/scripts/inpaint_anything.py
+++ b/scripts/inpaint_anything.py
@@ -1144,6 +1144,7 @@ def on_ui_tabs():
                 with gr.Row().style(equal_height=False):
                     with gr.Column():
                         expand_mask_btn = gr.Button("Expand mask region", elem_id="expand_mask_btn")
+                        expand_mask_iteration_count = gr.Slider(label="Expand Mask Iterations", elem_id="expand_mask_iteration_count", minimum=1, maximum=100, value=1, step=1)
                     with gr.Column():
                         apply_mask_btn = gr.Button("Trim mask by sketch", elem_id="apply_mask_btn")
                         add_mask_btn = gr.Button("Add mask by sketch", elem_id="add_mask_btn")
@@ -1156,7 +1157,7 @@ def on_ui_tabs():
                 fn=None, inputs=None, outputs=None, _js="inpaintAnything_clearSamMask")
             select_btn.click(select_mask, inputs=[input_image, sam_image, invert_chk, ignore_black_chk, sel_mask], outputs=[sel_mask]).then(
                 fn=None, inputs=None, outputs=None, _js="inpaintAnything_clearSelMask")
-            expand_mask_btn.click(expand_mask, inputs=[input_image, sel_mask], outputs=[sel_mask]).then(
+            expand_mask_btn.click(expand_mask, inputs=[input_image, sel_mask, expand_mask_iteration_count], outputs=[sel_mask]).then(
                 fn=None, inputs=None, outputs=None, _js="inpaintAnything_clearSelMask")
             apply_mask_btn.click(apply_mask, inputs=[input_image, sel_mask], outputs=[sel_mask]).then(
                 fn=None, inputs=None, outputs=None, _js="inpaintAnything_clearSelMask")

--- a/scripts/inpaint_anything.py
+++ b/scripts/inpaint_anything.py
@@ -1144,7 +1144,8 @@ def on_ui_tabs():
                 with gr.Row().style(equal_height=False):
                     with gr.Column():
                         expand_mask_btn = gr.Button("Expand mask region", elem_id="expand_mask_btn")
-                        expand_mask_iteration_count = gr.Slider(label="Expand Mask Iterations", elem_id="expand_mask_iteration_count", minimum=1, maximum=100, value=1, step=1)
+                        expand_mask_iteration_count = gr.Slider(label="Expand Mask Iterations",
+                                                                elem_id="expand_mask_iteration_count", minimum=1, maximum=100, value=1, step=1)
                     with gr.Column():
                         apply_mask_btn = gr.Button("Trim mask by sketch", elem_id="apply_mask_btn")
                         add_mask_btn = gr.Button("Add mask by sketch", elem_id="add_mask_btn")


### PR DESCRIPTION
## Brief

This PR adds a simple slider below the `Expand Mask` button which allows the user to specify the number of iterations to use for the mask expansion operation.

## Motivation for Change

Often times, dilating the mask region a single time is not enough to really impact the result in inpainting/cleaning. I often found myself having to spam the `Expand Mask` button which was slow since every time you press the button you have to wait for the image to reload before you can press again. This PR aims to make everyone's life a bit easier by just allowing them to set the number of iterations (dilation steps) for the `Expand Mask` operation.

## Additional Changes

- Increased the limit to the number of iterations within `inpaint_anything.py::expand_mask()`. Previously, the range was set to values of 1-5 however this seemed needlessly small so I upped the limit to 100 to reflect the max value of the slider.

## Tests

- [x] Tested various values for the iteration count slider.
- [x] Compared manually expanding mask 1 at a time for 15 iterations and expanding mask using an iteration count of 15. Both gave same result.

![image](https://github.com/Uminosachi/sd-webui-inpaint-anything/assets/146112734/69030265-02ce-4816-8c41-d75b35996429)
