### PR TITLE
Introduces "Segment Anything Models Directory" option to change default Segment Anything models directory

### DIFF
--- a/ia_file_manager.py
+++ b/ia_file_manager.py
@@ -15,7 +15,10 @@ class IAFileManager:
     def __init__(self) -> None:
         self.update_ia_outputs_dir()
 
-        self._ia_models_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), "models")
+        sam_models_dir = shared.opts.data.get("inpain_anything_sam_models_dir", "")
+        if (len(sam_models_dir) == 0) or (sam_models_dir.isspace()):
+            sam_models_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), "models")
+        self._ia_models_dir = sam_models_dir
 
     def update_ia_outputs_dir(self) -> None:
         """Update inpaint-anything outputs directory.

--- a/scripts/inpaint_anything.py
+++ b/scripts/inpaint_anything.py
@@ -1319,6 +1319,14 @@ def on_ui_settings():
                                component=gr.Slider,
                                component_args={"minimum": 0, "maximum": 255, "step": 1},
                                section=section))
+    shared.opts.add_option("inpain_anything_sam_models_dir",
+                           shared.OptionInfo(
+                                default="",
+                                label="Segment Anything Models Directory; If empty, defaults to [Inpaint Anything extension folder]/models",
+                                component=gr.Textbox,
+                                component_args={"interactive": True},
+                                section=section))
+
 
 
 script_callbacks.on_ui_settings(on_ui_settings)


### PR DESCRIPTION
Both Segment Anything and Inpaint Anything AUTOMATIC1111 extensions require "SAM" models to work, however they don't use the same directory for storing these models. The introduced  "Segment Anything Models Directory" allows Inpaint Anything to use Segment Anything models directory so that there won't be any need to have 2 sets of the same models in the file system.